### PR TITLE
ci: auto-add new issues + PRs to BamDude project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,25 @@
+name: Add to BamDude project
+
+# Auto-adds new issues + PRs to the user-level project board
+# https://github.com/users/kainpl/projects/3 so the board reflects every
+# repo in the BamDude umbrella (the app, this docs site, the landing).
+# The "Auto-add to project" built-in workflow on the project itself is
+# capped at one repo filter, so we wire it here per-repo via Actions.
+#
+# Requires repo secret PROJECTS_TOKEN — fine-grained PAT with Account
+# permissions → Projects: Read and write, scoped to this repository.
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/kainpl/projects/3
+          github-token: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
Same workflow as the BamDude app and landing repos — calls actions/add-to-project on issue / PR open or reopen so every umbrella repo feeds into https://github.com/users/kainpl/projects/3 without relying on the project's single-repo built-in Auto-add. Requires repo secret PROJECTS_TOKEN (classic PAT with the `project` scope).