### PR TITLE
ci: pin actions/add-to-project to v1.0.2

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,7 +19,7 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/users/kainpl/projects/3
           github-token: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
The maintainers don't push a moving v1 major tag — only specific patch versions. @v1 fails to resolve and breaks the workflow on every new issue.