### PR TITLE
docs(upgrading): restore Scenario 1 + Switching install method, drop …

### DIFF
--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -171,32 +171,148 @@ Migrations marked **seed** include a DML step (data backfill / normalisation) an
 
 ## :material-arrow-decision: 5. Notable upgrade paths
 
-### From Bambuddy 3.0.x → BamDude 0.4.x
+### From Bambuddy HE 3.0.x → BamDude 0.4.x
 
 `m000` imports your data, `m002` adapts the schema, `m005`+ are BamDude-native.
 
 !!! warning "Always upgrade to **0.4.0.1** or later"
     Going from a legacy 3.0.1 install straight to **0.4.0** crashed at `m005_swap_profiles.seed()` with `no such column: printers.awaiting_plate_clear` — the seed used ORM `select(Printer)` which loaded every column from the *current* model, including columns that don't exist yet at m005's point in the chain. Fixed in 0.4.0.1 by rewriting the seed to use raw SQL with explicit column lists.
 
-### From BamDude 0.3.x → 0.4.x
+---
 
-- `m012` adds the MFA cluster (6 new tables + `password_changed_at` on users).
-- Existing users keep their existing JWT tokens until they next log in. From the next login onward, sliding-session refresh tokens take over (access JWT TTL drops from 24 h to 1 h, but a rotating refresh cookie keeps you signed in transparently). Pre-existing browser sessions don't have a refresh cookie yet, so they'll start failing 401s once their stored access token's 24 h TTL expires — at that point the user is bounced to `/login` and the new flow kicks in.
-- `m014` backfills `library_file_id` on existing archives by hash matching, and **overwrites** `library_files.print_count` / `last_printed_at` with values derived from completed-archive history. Manual fixups to those fields from before the migration are discarded — archive history wins.
-- `m019` is the queue↔archive refactor; cached terminal counters move off `printer_queues` and now compute on read from `print_archives`. Completed queue items auto-delete in `on_print_complete`.
-- `m021` drops `printers.auto_light_off`. If you relied on that flag, recreate the behaviour by configuring a `chamber_light_off` mqtt-action macro on the `print_started` event after the upgrade.
+## :material-swap-horizontal: Scenario 1 — Migrating from Bambuddy 2.2.2
 
-### From BamDude 0.4.0 → 0.4.1
+Place a Bambuddy DB file next to where BamDude expects to find it. On first boot the `m000_bambuddy_import` migration detects it, imports every table BamDude still uses, and renames the file to `bamdude.db`.
 
-- `m022` opens every 3MF on disk to extract two new metadata fields (`gcode_label_objects`, `exclude_object`). Expect a long startup on installs with thousands of archives — roughly **50–200 ms per file**, several minutes for a multi-thousand-archive farm before the API comes up.
-- The seed commits in batches of **100** and logs progress every batch. Watch for these log lines:
+The original Bambuddy file is **left in place** (not deleted) so you can roll back.
 
-    ```text
-    INFO  [backend.app.migrations] m022 library_files: progress 100/847
-    INFO  [backend.app.migrations] m022 print_archives: progress 1500/3261
-    ```
+### via Docker Compose (source checkout)
 
-- 3MFs that were deleted from disk (history rows whose file is gone) are skipped silently — those rows just stay without the new fields. The migration is fully one-shot; the `_migrations` table prevents re-runs even if you restart mid-run.
+```bash
+# 1. Stop Bambuddy
+cd /path/to/bambuddy && docker compose down
+
+# 2. Clone BamDude
+git clone https://github.com/kainpl/bamdude.git
+cd bamdude
+
+# 3. Copy your Bambuddy DB + archives into the bamdude_data volume
+docker volume create bamdude_data
+docker run --rm \
+  -v /path/to/bambuddy/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# 4. Start — migrations run automatically on first boot
+docker compose up -d
+
+# 5. Follow startup logs, look for "Bambuddy → BamDude import complete"
+docker compose logs -f bamdude
+```
+
+### via `docker run` (GHCR image)
+
+```bash
+# 1. Stop Bambuddy (however you run it)
+
+# 2. Create the new volume and seed it with your Bambuddy data
+docker volume create bamdude_data
+docker run --rm \
+  -v /path/to/bambuddy/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# 3. Start BamDude from GHCR
+docker run -d \
+  --name bamdude \
+  --network host \
+  -e TZ=Europe/Kyiv \
+  -v bamdude_data:/app/data \
+  -v bamdude_logs:/app/logs \
+  --restart unless-stopped \
+  ghcr.io/kainpl/bamdude:latest
+```
+
+### via native / self-install
+
+```bash
+# 1. Stop the Bambuddy service
+
+# 2. Install BamDude
+curl -fsSL https://raw.githubusercontent.com/kainpl/bamdude/main/install/install.sh \
+  -o install.sh && chmod +x install.sh
+sudo ./install.sh --yes       # defaults to /opt/bamdude
+
+# 3. Drop your Bambuddy DB into BamDude's data dir BEFORE first start
+sudo cp /path/to/bambuddy/data/bambuddy.db /opt/bamdude/data/
+sudo cp -r /path/to/bambuddy/data/archives /opt/bamdude/data/   # if you have one
+
+# 4. Fix ownership (installer runs as the bamdude service user)
+sudo chown -R bamdude:bamdude /opt/bamdude/data/
+
+# 5. Start the service — import migration fires automatically
+sudo systemctl start bamdude
+sudo journalctl -u bamdude -f
+```
+
+!!! tip "The import is one-shot"
+    `m000_bambuddy_import` checks for `bambuddy.db` / `bambutrack.db` and only runs if BamDude's own `bamdude.db` does not yet exist. After a successful import the file is renamed to `bamdude.db` and the migration is marked applied in the `_migrations` table, so a subsequent restart won't re-import.
+
+---
+
+## :material-compare-horizontal: Switching install method
+
+You can change install method at any time without touching data — just point the new instance at the existing `data/` directory or copy the volume contents.
+
+### Native → Docker
+
+```bash
+sudo systemctl stop bamdude
+
+# Copy native data into a Docker volume
+docker volume create bamdude_data
+docker run --rm \
+  -v /opt/bamdude/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# Start the GHCR image against the new volume
+docker run -d --name bamdude --network host \
+  -v bamdude_data:/app/data -v bamdude_logs:/app/logs \
+  --restart unless-stopped ghcr.io/kainpl/bamdude:latest
+
+# Only after you've verified the Docker instance works, disable/remove the native service:
+sudo systemctl disable bamdude
+```
+
+### Docker → Native
+
+```bash
+docker compose down
+
+# Copy the volume out to disk
+docker run --rm \
+  -v bamdude_data:/from \
+  -v "$(pwd)/extracted":/to \
+  alpine cp -a /from/. /to/
+
+# Install native pointing at the extracted data
+sudo ./install/install.sh --data-dir "$(pwd)/extracted" --yes
+```
+
+### Docker Hub → GHCR (or vice versa)
+
+Registry swap only, no data touch:
+
+```bash
+# docker-compose.yml
+# image: kainpl/bamdude:latest      ← Docker Hub
+# image: ghcr.io/kainpl/bamdude:latest  ← GitHub Container Registry
+docker compose pull
+docker compose up -d
+```
+
+Both registries publish the same tags. GHCR is the preferred source (built in CI on every release); Docker Hub is a mirror.
 
 ---
 

--- a/docs/getting-started/upgrading.uk.md
+++ b/docs/getting-started/upgrading.uk.md
@@ -171,32 +171,148 @@ BamDude трекає застосовані міграції в таблиці `
 
 ## :material-arrow-decision: 5. Помітні шляхи оновлення
 
-### З Bambuddy 3.0.x → BamDude 0.4.x
+### З Bambuddy HE 3.0.x → BamDude 0.4.x
 
 `m000` імпортує ваші дані, `m002` адаптує схему, `m005`+ -- BamDude-нативні.
 
 !!! warning "Завжди оновлюйтесь до **0.4.0.1** або пізніше"
     Перехід зі спадкової інсталяції 3.0.1 одразу на **0.4.0** падав на `m005_swap_profiles.seed()` з `no such column: printers.awaiting_plate_clear` -- seed використовував ORM-овий `select(Printer)`, який підвантажував кожну колонку з *поточної* моделі, включно з колонками, яких на момент m005 у ланцюжку ще не існує. Виправлено в 0.4.0.1 переписуванням seed на raw SQL з явними списками колонок.
 
-### З BamDude 0.3.x → 0.4.x
+---
 
-- `m012` додає кластер MFA (6 нових таблиць + `password_changed_at` на users).
-- Наявні користувачі тримають свої наявні JWT-токени до наступного логіну. З наступного логіну на сцену виходять sliding-session refresh-токени (TTL access JWT падає з 24 г до 1 г, але ротуючий refresh-cookie тримає вас залогіненими прозоро). Сесії браузера, що були до оновлення, ще не мають refresh-cookie, тож вони почнуть фейлитись на 401, щойно TTL збереженого access-токена в 24 г закінчиться -- у цей момент користувача викидає на `/login` і вмикається новий флоу.
-- `m014` бекфілить `library_file_id` на наявних архівах через hash-метчинг і **перезаписує** `library_files.print_count` / `last_printed_at` значеннями, виведеними з історії завершених архівів. Ручні правки цих полів до міграції відкидаються -- історія архівів виграє.
-- `m019` -- це рефакторинг queue↔archive; кешовані термінальні лічильники з'їжджають з `printer_queues` і тепер обчислюються при читанні з `print_archives`. Завершені елементи черги авто-видаляються в `on_print_complete`.
-- `m021` дропає `printers.auto_light_off`. Якщо ви покладались на цей прапорець, відтворіть поведінку, сконфігурувавши mqtt-action макрос `chamber_light_off` на події `print_started` після оновлення.
+## :material-swap-horizontal: Сценарій 1 -- Міграція з Bambuddy 2.2.2
 
-### З BamDude 0.4.0 → 0.4.1
+Покладіть файл Bambuddy DB поруч із тим місцем, де BamDude очікує його знайти. На першому завантаженні міграція `m000_bambuddy_import` його виявить, імпортує кожну таблицю, яку BamDude ще використовує, та перейменує файл на `bamdude.db`.
 
-- `m022` відкриває кожен 3MF на диску, щоб витягти два нових поля метаданих (`gcode_label_objects`, `exclude_object`). Очікуйте довгий старт на інсталяціях з тисячами архівів -- приблизно **50--200 мс на файл**, кілька хвилин для ферми з кількома тисячами архівів, поки API підніметься.
-- Seed комітить пакетами по **100** і логує прогрес кожним пакетом. Слідкуйте за цими рядками логу:
+Оригінальний файл Bambuddy **залишається на місці** (не видаляється), тож можна відкотитись.
 
-    ```text
-    INFO  [backend.app.migrations] m022 library_files: progress 100/847
-    INFO  [backend.app.migrations] m022 print_archives: progress 1500/3261
-    ```
+### через Docker Compose (source checkout)
 
-- 3MF, видалені з диска (рядки історії, чий файл зник), мовчки пропускаються -- ці рядки просто лишаються без нових полів. Міграція повністю one-shot; таблиця `_migrations` запобігає повторним запускам, навіть якщо ви рестартнете посеред.
+```bash
+# 1. Зупиніть Bambuddy
+cd /path/to/bambuddy && docker compose down
+
+# 2. Клонуйте BamDude
+git clone https://github.com/kainpl/bamdude.git
+cd bamdude
+
+# 3. Скопіюйте свою Bambuddy DB + архіви у том bamdude_data
+docker volume create bamdude_data
+docker run --rm \
+  -v /path/to/bambuddy/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# 4. Старт -- міграції запускаються автоматично на першому завантаженні
+docker compose up -d
+
+# 5. Слідкуйте за стартовими логами, шукайте "Bambuddy → BamDude import complete"
+docker compose logs -f bamdude
+```
+
+### через `docker run` (GHCR-образ)
+
+```bash
+# 1. Зупиніть Bambuddy (як би ви його не запускали)
+
+# 2. Створіть новий том і засійте його даними з Bambuddy
+docker volume create bamdude_data
+docker run --rm \
+  -v /path/to/bambuddy/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# 3. Стартуйте BamDude з GHCR
+docker run -d \
+  --name bamdude \
+  --network host \
+  -e TZ=Europe/Kyiv \
+  -v bamdude_data:/app/data \
+  -v bamdude_logs:/app/logs \
+  --restart unless-stopped \
+  ghcr.io/kainpl/bamdude:latest
+```
+
+### через native / self-install
+
+```bash
+# 1. Зупиніть сервіс Bambuddy
+
+# 2. Встановіть BamDude
+curl -fsSL https://raw.githubusercontent.com/kainpl/bamdude/main/install/install.sh \
+  -o install.sh && chmod +x install.sh
+sudo ./install.sh --yes       # за замовчуванням /opt/bamdude
+
+# 3. Покладіть свою Bambuddy DB у data-директорію BamDude ДО першого старту
+sudo cp /path/to/bambuddy/data/bambuddy.db /opt/bamdude/data/
+sudo cp -r /path/to/bambuddy/data/archives /opt/bamdude/data/   # якщо є
+
+# 4. Виправте власника (інсталер працює від користувача сервісу bamdude)
+sudo chown -R bamdude:bamdude /opt/bamdude/data/
+
+# 5. Стартуйте сервіс -- міграція імпорту запуститься автоматично
+sudo systemctl start bamdude
+sudo journalctl -u bamdude -f
+```
+
+!!! tip "Імпорт -- one-shot"
+    `m000_bambuddy_import` перевіряє наявність `bambuddy.db` / `bambutrack.db` і запускається, лише якщо власного `bamdude.db` BamDude ще немає. Після успішного імпорту файл перейменовується на `bamdude.db` і міграція позначається як applied у таблиці `_migrations`, тож наступний рестарт не імпортуватиме повторно.
+
+---
+
+## :material-compare-horizontal: Зміна способу інсталяції
+
+Можна змінити спосіб інсталяції в будь-який момент без зачіпання даних -- просто наведіть нову інстанцію на існуючу директорію `data/` або скопіюйте вміст тому.
+
+### Native → Docker
+
+```bash
+sudo systemctl stop bamdude
+
+# Скопіюйте native-дані в Docker-том
+docker volume create bamdude_data
+docker run --rm \
+  -v /opt/bamdude/data:/from \
+  -v bamdude_data:/to \
+  alpine cp -a /from/. /to/
+
+# Стартуйте GHCR-образ проти нового тому
+docker run -d --name bamdude --network host \
+  -v bamdude_data:/app/data -v bamdude_logs:/app/logs \
+  --restart unless-stopped ghcr.io/kainpl/bamdude:latest
+
+# Лише після того, як ви переконались, що Docker-інстанція працює, вимкніть/видаліть native-сервіс:
+sudo systemctl disable bamdude
+```
+
+### Docker → Native
+
+```bash
+docker compose down
+
+# Скопіюйте том на диск
+docker run --rm \
+  -v bamdude_data:/from \
+  -v "$(pwd)/extracted":/to \
+  alpine cp -a /from/. /to/
+
+# Встановіть native, націлений на витягнуті дані
+sudo ./install/install.sh --data-dir "$(pwd)/extracted" --yes
+```
+
+### Docker Hub → GHCR (або навпаки)
+
+Лише обмін реєстром, дані не торкаємо:
+
+```bash
+# docker-compose.yml
+# image: kainpl/bamdude:latest      ← Docker Hub
+# image: ghcr.io/kainpl/bamdude:latest  ← GitHub Container Registry
+docker compose pull
+docker compose up -d
+```
+
+Обидва реєстри публікують ті самі теги. GHCR -- основне джерело (білдиться в CI на кожному релізі); Docker Hub -- дзеркало.
 
 ---
 


### PR DESCRIPTION
…stale 0.3.x/0.4.0→0.4.1 sections

Restores two sections that were dropped during the 0.4.1 docs rewrite:
- "Scenario 1 — Migrating from Bambuddy 2.2.2" (Docker Compose, docker run, and native variants).
- "Switching install method" (Native↔Docker, Docker→Native, Docker Hub↔GHCR).

Also in §5 Notable upgrade paths:
- Rename "From Bambuddy 3.0.x → BamDude 0.4.x" to "From Bambuddy HE 3.0.x → BamDude 0.4.x" so it's clear we mean the HE fork, not upstream 3.x.
- Drop the now-stale "From BamDude 0.3.x → 0.4.x" and "From BamDude 0.4.0 → 0.4.1" callouts — both are too far back to be load-bearing on a fresh 0.4.2+ install and the same info lives in the migration matrix above.

Both en and uk locales updated.