### PR TITLE
docs(tailscale): add Docker binary mount + Troubleshooting table

### DIFF
--- a/docs/features/tailscale.md
+++ b/docs/features/tailscale.md
@@ -28,7 +28,17 @@ Tailscale shines specifically when **the slicer-running machine is already on Ta
 
 ## :material-package-variant: Prerequisites
 
-1. **Tailscale daemon on the BamDude host.** Native installs: install [tailscaled](https://tailscale.com/kb/1031/install-linux) and `tailscale up`. Docker installs: mount the host's tailscaled socket / state into the container (`/var/run/tailscale/tailscaled.sock`) so BamDude can shell out to `tailscale cert`. There's no in-image tailscaled — ship the daemon on the host, BamDude just consumes it.
+1. **Tailscale daemon on the BamDude host.** Native installs: install [tailscaled](https://tailscale.com/kb/1031/install-linux) and `tailscale up`. Docker installs need **two** bind-mounts (the BamDude image bundles neither — see Caveats below):
+
+    ```yaml
+    services:
+      bamdude:
+        volumes:
+          - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+          - /usr/bin/tailscale:/usr/bin/tailscale:ro
+    ```
+
+    The socket lets BamDude talk to the host daemon; the binary is the CLI client BamDude shells out to (`shutil.which("tailscale")` returns `None` without it, and the integration self-disables). Daemon stays on the host, BamDude just consumes it.
 2. **MagicDNS + HTTPS certificates enabled** on your tailnet — both are toggles on the [Tailscale admin DNS page](https://login.tailscale.com/admin/dns). Without them you don't get the `*.ts.net` FQDN BamDude needs to mint a cert against.
 3. **A virtual printer.** Tailscale flips a flag *per VP*; you need at least one VP to flip it on.
 
@@ -80,6 +90,23 @@ LAN advertising still happens too — local slicers pick up the LAN IP, remote s
 - **`tailscaled` must be on the host (or mounted from a sidecar) — BamDude can't bring it up.** This is a deliberate split: Tailscale's auth + state model is a host concern.
 - **Private tailnets only** — there's no path to advertise a VP to the public internet through this. That's by design (and what `proxy` mode is for).
 - **Cert renewal needs daemon access at runtime** — if the host's tailscaled goes offline, the daily renewal will start failing 30+ days before the cert expires; check the alerts.
+
+---
+
+## :material-bug-outline: Troubleshooting
+
+When VP startup falls back to the self-signed cert, the reason is in the BamDude logs at WARNING level. Match the message to the fix:
+
+| Log message | Cause | Fix |
+|---|---|---|
+| `tailscale binary not found` | CLI not on `PATH`. Bare-metal: not installed. Docker: binary not bind-mounted. | Bare-metal: install [tailscaled](https://tailscale.com/kb/1031/install-linux). Docker: add `- /usr/bin/tailscale:/usr/bin/tailscale:ro` (in addition to the socket mount). |
+| `Running in Docker but /var/run/tailscale/tailscaled.sock is not mounted` | One-time hint at startup when the binary's there but the socket isn't. | Add `- /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock` to `volumes:`. |
+| `Tailscale not connected (no DNSName)` | Daemon up but the host hasn't joined a tailnet. | `tailscale up` on the host and authenticate. |
+| `https cert ... disabled` / `not enabled tailnet` / `cert ... not enabled` | HTTPS Certificates toggle off in the admin console. | Enable MagicDNS + HTTPS Certificates at [login.tailscale.com/admin/dns](https://login.tailscale.com/admin/dns). On a corporate / school tailnet you may need an admin to flip it. |
+| `Tailscale cert files at ... are not readable by this process` | Bare-metal install where `tailscale cert` ran as root and left files root-owned. | `sudo chown $(whoami):$(whoami) <data>/certs/<vp_id>/*` — message includes the exact path and command. |
+| `tailscale cert failed (exit N): ...` | Anything else from the CLI (rate limit, FQDN typo, daemon mid-restart). | Read the stderr in the log line; rate-limits self-resolve in an hour, FQDN issues mean the VP name has characters Tailscale won't accept. |
+
+In every case the VP keeps running on the self-signed cert — fix the upstream and either restart the VP or wait for the next 24h renewal pass to retry.
 
 ---
 

--- a/docs/features/tailscale.uk.md
+++ b/docs/features/tailscale.uk.md
@@ -28,7 +28,17 @@ Tailscale світиться особливо коли **машина, де кр
 
 ## :material-package-variant: Передумови
 
-1. **Демон Tailscale на хості BamDude.** Native-інстал: встанови [tailscaled](https://tailscale.com/kb/1031/install-linux) і `tailscale up`. Docker-інстал: примонтуй сокет / state daemon'а хоста в контейнер (`/var/run/tailscale/tailscaled.sock`), щоб BamDude міг shell-out на `tailscale cert`. Жодного in-image tailscaled — daemon живе на хості, BamDude лише читає його.
+1. **Демон Tailscale на хості BamDude.** Native-інстал: встанови [tailscaled](https://tailscale.com/kb/1031/install-linux) і `tailscale up`. Docker-інстал потребує **двох** bind-mount'ів (BamDude image не містить ні того, ні іншого — див. Caveats нижче):
+
+    ```yaml
+    services:
+      bamdude:
+        volumes:
+          - /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock
+          - /usr/bin/tailscale:/usr/bin/tailscale:ro
+    ```
+
+    Сокет дозволяє BamDude говорити з демоном хоста; бінарник — це CLI-клієнт, на який BamDude shell-out'ить (`shutil.which("tailscale")` повертає `None` без нього, і інтеграція сама вимикається). Daemon живе на хості, BamDude лише читає його.
 2. **MagicDNS + HTTPS-сертифікати ввімкнені** на твоєму tailnet'і — обидві опції на [Tailscale admin DNS page](https://login.tailscale.com/admin/dns). Без них немає `*.ts.net` FQDN, проти якого BamDude буде випустити серт.
 3. **Віртуальний принтер.** Tailscale тогглиться *per VP*; потрібен принаймні один VP, щоб увімкнути.
 
@@ -80,6 +90,23 @@ LAN-анонс теж відбувається — локальні слайсе
 - **`tailscaled` має бути на хості (або примонтований із sidecar) — BamDude не може його підняти.** Це навмисний поділ: auth + state model Tailscale — host-concern.
 - **Лише приватні tailnet'и** — публічного інтернет-анонсу VP через це немає. Це by design (для цього є `proxy` mode).
 - **Cert renewal потребує доступ до daemon у час виконання** — якщо tailscaled на хості ляже, daily-renewal почне фейлити за 30+ днів до експірації серта; стеж за алертами.
+
+---
+
+## :material-bug-outline: Усунення проблем
+
+Якщо при старті VP відбувається фолбек на самопідписаний серт — причина в логах BamDude на рівні WARNING. Зіставляй повідомлення з фіксом:
+
+| Повідомлення в логу | Причина | Фікс |
+|---|---|---|
+| `tailscale binary not found` | CLI не у `PATH`. Bare-metal: не встановлено. Docker: бінарник не примонтований. | Bare-metal: встанови [tailscaled](https://tailscale.com/kb/1031/install-linux). Docker: додай `- /usr/bin/tailscale:/usr/bin/tailscale:ro` (на додачу до сокет-маунту). |
+| `Running in Docker but /var/run/tailscale/tailscaled.sock is not mounted` | Одноразова підказка на старті, коли бінарник є, але сокета — нема. | Додай `- /var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock` у `volumes:`. |
+| `Tailscale not connected (no DNSName)` | Daemon піднятий, але хост не залогінений у tailnet. | `tailscale up` на хості, авторизація. |
+| `https cert ... disabled` / `not enabled tailnet` / `cert ... not enabled` | Toggle HTTPS Certificates вимкнений в admin-консолі. | Увімкни MagicDNS + HTTPS Certificates на [login.tailscale.com/admin/dns](https://login.tailscale.com/admin/dns). У корпоративному / шкільному tailnet'і може знадобитися admin, щоб це перемкнути. |
+| `Tailscale cert files at ... are not readable by this process` | Bare-metal-інстал, де `tailscale cert` запустився під root, і файли лишилися root-owned. | `sudo chown $(whoami):$(whoami) <data>/certs/<vp_id>/*` — у логу буде точний шлях і команда. |
+| `tailscale cert failed (exit N): ...` | Будь-що інше від CLI (rate-limit, неправильний FQDN, daemon у мить рестарту). | Читай stderr у тому ж рядку логу; rate-limit'и самі вирішуються за годину, проблеми з FQDN означають що ім'я VP має символи, які Tailscale не приймає. |
+
+У будь-якому випадку VP продовжує працювати на самопідписаному серті — виправ root cause, після чого або рестарни VP, або дочекайся наступного 24h renewal-проходу.
 
 ---
 


### PR DESCRIPTION
Prerequisites step 1 now spells out both bind-mounts Docker installs need (socket + `/usr/bin/tailscale` binary). Earlier text mentioned only the socket — users following the snippet hit `tailscale binary not found` and didn't know why.

New "Troubleshooting" / "Усунення проблем" section with a log-message → cause → fix table covering: missing binary, missing socket, daemon not joined, HTTPS toggle off in admin console, root-owned cert files on bare-metal, and generic CLI errors.