### PR TITLE
docs(why): align EN headings with nav label

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Hard fork of [Bambuddy](https://github.com/maziggy/bambuddy) with per-printer qu
 
 ---
 
-## :material-help-circle-outline: Why this exists
+## :material-help-circle-outline: Why BamDude
 
 BamDude is a **fleet manager**, not a passive backend that just listens to your slicer. The classic "slice → print → BamDude logs whatever it can" flow is fine for one or two printers, but it falls apart the moment accurate history and real spool control start mattering.
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -3,7 +3,7 @@ title: Why BamDude
 description: BamDude is a fleet manager — not a passive backend listening to your slicer. Why that distinction matters and how to think about plugging it into your workflow.
 ---
 
-# Why this exists
+# Why BamDude
 
 ## Two ways to drive a 3D printer
 


### PR DESCRIPTION
Page H1 was "Why this exists" while the top-nav and homepage already read "Why BamDude" — small consistency drift. Renamed both the /why H1 and the homepage teaser section header to match the nav.